### PR TITLE
Add tests for dual-apis

### DIFF
--- a/.claude/skills/coding-style/SKILL.md
+++ b/.claude/skills/coding-style/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: coding-style
+description: Guidelines for formatting TypeScript code in the fx-fetch package.
+---
+
+# Format Skill
+
+This skill should be used only for library code, test code, and code snippets in JSDoc.
+
+**Target Files**: `packages/fx-fetch/**/*.ts`
+
+**When to use**: Use this skill after writing or modifying TypeScript code in the fx-fetch package to ensure it follows project style guidelines.
+
+## Workflow
+
+1. Run `pnpm fmt:write` to apply automatic formatting
+2. Apply the manual style guidelines from this skill
+3. Run `pnpm fmt:write` again to ensure formatting is correct
+4. Verify changes by running `pnpm validate` and `pnpm test`
+
+This skill can operate in three modes: library code, test code, and JSDoc code snippets.
+
+## Common Guidelines
+
+1. Always use single quotes for strings. Use template literals when interpolation is needed.
+2. Wrap switch cases in curly braces.
+3. Use trailing commas in multi-line object and array literals.
+4. Keep blank line after import statements.
+5. Keep blank line after if/else blocks.
+6. Use explicit return types for top-level functions and methods. This rule can be relaxed for small inline functions.
+7. Prefer immutable data structures and avoid mutating function parameters.
+
+After all changes, run `pnpm fmt:write` to ensure formatting is correct.
+Also run `pnpm validate` and `pnpm test` to verify no issues were introduced.
+
+---
+
+## Library Code
+
+Use common guidelines plus the following:
+
+Take care about `verbatimModuleSyntax` option in `tsconfig.json`. Take care about best tree-shaking practices. Import only what is necessary.
+
+1. If we import a type from a `effect` package, we should import it from its specific module path instead of the root package to ensure better tree shaking. (e.g., `import { type Effect } from 'effect/Effect';`)
+2. If we import functions with same name from different modules, we should alias them to avoid naming conflicts. (e.g., `import { map as effectMap } from 'effect/Effect';`)
+3. Avoid using `import * as` syntax to prevent importing unnecessary code. Only exception is when importing file "localThis.ts" as module namespace. (e.g., `import * as localThis from './localThis';`)
+4. Remove any unused imports to keep the code clean.
+
+---
+
+## Test Code
+
+Use common guidelines plus the following:
+
+1. Use `describe` blocks to group related tests together.
+2. Use `it` blocks for individual test cases.
+3. Use simple test names that clearly describe the behavior being tested. Do not be too generic and verbose.
+4. Make small tests that focus on a single behavior or scenario.
+5. Make small amount of test data needed for the test.
+6. Test edge cases and error scenarios.
+7. Test types using `expectTypeOf` from `vitest` library.
+8. Use verbose variable and function names to improve readability.
+9. Import library code functions from root file instead of specific module paths to ensure testing the public API.
+10. Import EffectTS stuff from root package paths instead of specific module paths to ensure testing the public API. (e.g., `import { Effect, Option, Either } from 'effect';`)
+
+---
+
+## JSDoc and JSDoc Code Snippets
+
+Use common guidelines plus the following:
+
+1. We want to use only following JSDoc tags: `@since`, `@example`, `@category`, `@see`, `@link`, `@internal` and `@deprecated`.
+2. The JSDoc tags `@since`, `@category`, and `@example` should always be present in public API documentation. Other tags can be used as needed.
+3. Ensure that code snippets in JSDoc comments are properly formatted and follow the same guidelines as library code.
+4. Ensure that code snippets are relevant to the surrounding documentation and accurately illustrate the concepts being discussed.
+5. Ensure that code snippets are complete and can be understood in isolation.
+6. Use triple backticks (```) to denote code blocks in JSDoc comments.
+7. Specify the language for code blocks in JSDoc comments (e.g., ```ts for TypeScript code).
+8. Avoid using overly complex code snippets that may confuse readers.
+9. Use "ASCII" arrows for describing focused types in JSDoc examples. Use characters `◀︎ ▶︎ ▲ ▼ ┌ ┐ └ ┘ ─ │` to draw boxes around focused types in JSDoc examples.
+10. Make sure to have same JSDoc comments for overloaded functions. (e.g., Dual APIs functions)

--- a/packages/fx-fetch/src/Fetch/fetchJsonWithSchema.test.ts
+++ b/packages/fx-fetch/src/Fetch/fetchJsonWithSchema.test.ts
@@ -1,0 +1,43 @@
+import { Effect, Layer, Schema } from 'effect';
+import { describe, expect, expectTypeOf, test } from 'vitest';
+import * as Request from '../Request';
+import * as Response from '../Response';
+import * as Fetch from '.';
+
+describe('Fetch.fetchJsonWithSchema', () => {
+  const request = Request.unsafeMake({ url: 'https://example.com' });
+
+  const schema = Schema.Struct({
+    name: Schema.String,
+    age: Schema.Int,
+  });
+
+  const mockFetch = Fetch.Fetch.of((_req: Request.Request) =>
+    Effect.succeed(
+      Response.unsafeMake({
+        ok: true,
+        status: 200,
+        statusText: '200 OK',
+        type: 'default',
+        url: 'https://example.com',
+        body: `{"name":"John","age":30}`,
+      })
+    )
+  );
+
+  const mockLayer = Layer.succeed(Fetch.Fetch, mockFetch);
+
+  test('dualApi', async () => {
+    const a = await Fetch.fetchJsonWithSchema(request, schema).pipe(
+      Effect.provide(mockLayer),
+      Effect.runPromiseExit
+    );
+    const b = await Fetch.fetchJsonWithSchema(schema)(request).pipe(
+      Effect.provide(mockLayer),
+      Effect.runPromiseExit
+    );
+
+    expect(a).toEqual(b);
+    expectTypeOf(a).toEqualTypeOf(b);
+  });
+});

--- a/packages/fx-fetch/src/Fetch/fetchStream.test.ts
+++ b/packages/fx-fetch/src/Fetch/fetchStream.test.ts
@@ -1,0 +1,69 @@
+import { Chunk, Effect, Layer, Stream } from 'effect';
+import { describe, expectTypeOf, test } from 'vitest';
+import * as Request from '../Request';
+import * as Response from '../Response';
+import * as Fetch from '.';
+
+function _collectUint8ArrayStream(
+  stream: Stream.Stream<Uint8Array<ArrayBufferLike>, Error, never>
+): Promise<Uint8Array<ArrayBufferLike>> {
+  return Stream.runCollect(stream)
+    .pipe(
+      Effect.map((chunk) => {
+        const parts = Chunk.toReadonlyArray(chunk);
+        const totalLength = parts.reduce((sum, p) => sum + p.length, 0);
+        const out = new Uint8Array(totalLength);
+        let offset = 0;
+        for (const part of parts) {
+          out.set(part, offset);
+          offset += part.length;
+        }
+        return out;
+      })
+    )
+    .pipe(Effect.runPromise);
+}
+
+describe('Fetch.fetchStream', () => {
+  const request = Request.unsafeMake({ url: 'https://example.com' });
+
+  const options = {
+    onError: (error: unknown) => new Error('Stream error', { cause: error }),
+  };
+
+  const mockFetch = Fetch.Fetch.of((_req: Request.Request) =>
+    Effect.succeed(
+      Response.unsafeMake({
+        ok: true,
+        status: 200,
+        statusText: '200 OK',
+        type: 'default',
+        url: 'https://example.com',
+        body: `{"name":"John","age":30}`,
+      })
+    )
+  );
+
+  const _mockLayer = Layer.succeed(Fetch.Fetch, mockFetch);
+
+  test('dualApi', () => {
+    const aStream = Fetch.fetchStream(request, options);
+    const bStream = Fetch.fetchStream(options)(request);
+
+    // Streams are not directly comparable, only verify types match
+    expectTypeOf(aStream).toEqualTypeOf(bStream);
+  });
+
+  test('dualApi with optional releaseLockOnEnd', () => {
+    const optionsWithRelease = {
+      onError: (error: unknown) => new Error('Stream error', { cause: error }),
+      releaseLockOnEnd: true,
+    };
+
+    const aStream = Fetch.fetchStream(request, optionsWithRelease);
+    const bStream = Fetch.fetchStream(optionsWithRelease)(request);
+
+    // Streams are not directly comparable, only verify types match
+    expectTypeOf(aStream).toEqualTypeOf(bStream);
+  });
+});

--- a/packages/fx-fetch/src/Fetch/paginatedFetch.test.ts
+++ b/packages/fx-fetch/src/Fetch/paginatedFetch.test.ts
@@ -1,0 +1,62 @@
+import { Effect, Layer, Option, Schema } from 'effect';
+import { describe, expect, expectTypeOf, test } from 'vitest';
+import * as Request from '../Request';
+import * as Response from '../Response';
+import * as Fetch from '.';
+
+describe('Fetch.paginatedFetch', () => {
+  const request = Request.unsafeMake({ url: 'https://example.com' });
+
+  const ItemSchema = Schema.Struct({
+    id: Schema.Int,
+    name: Schema.String,
+  });
+
+  const PayloadSchema = Schema.Struct({
+    nextToken: Schema.String.pipe(Schema.optional),
+    items: Schema.Array(ItemSchema),
+  });
+
+  const onResponse = Effect.fn(function* (lastResponse: Response.Response) {
+    const payload = yield* Response.readJsonWithSchema(lastResponse, PayloadSchema);
+
+    const nextToken = Option.fromNullable(payload.nextToken);
+    const nextRequest = nextToken.pipe(
+      Option.map((token) => Request.setUrlSearchParam(request, 'token', token))
+    );
+
+    return {
+      pageEmission: payload.items,
+      nextRequest,
+    };
+  });
+
+  const mockFetch = Fetch.Fetch.of((_req: Request.Request) =>
+    Effect.succeed(
+      Response.unsafeMake({
+        ok: true,
+        status: 200,
+        statusText: '200 OK',
+        type: 'default',
+        url: 'https://example.com',
+        body: `{"items":[{"id":1,"name":"John"}]}`,
+      })
+    )
+  );
+
+  const mockLayer = Layer.succeed(Fetch.Fetch, mockFetch);
+
+  test('dualApi', async () => {
+    const a = await Fetch.paginatedFetch(request, onResponse).pipe(
+      Effect.provide(mockLayer),
+      Effect.runPromiseExit
+    );
+    const b = await Fetch.paginatedFetch(onResponse)(request).pipe(
+      Effect.provide(mockLayer),
+      Effect.runPromiseExit
+    );
+
+    expect(a).toEqual(b);
+    expectTypeOf(a).toEqualTypeOf(b);
+  });
+});

--- a/packages/fx-fetch/src/Fetch/paginatedFetchStream.test.ts
+++ b/packages/fx-fetch/src/Fetch/paginatedFetchStream.test.ts
@@ -1,0 +1,56 @@
+import { Effect, Layer, Option, Schema } from 'effect';
+import { describe, expectTypeOf, test } from 'vitest';
+import * as Request from '../Request';
+import * as Response from '../Response';
+import * as Fetch from '.';
+
+describe('Fetch.paginatedFetchStream', () => {
+  const request = Request.unsafeMake({ url: 'https://example.com' });
+
+  const ItemSchema = Schema.Struct({
+    id: Schema.Int,
+    name: Schema.String,
+  });
+
+  const PayloadSchema = Schema.Struct({
+    nextToken: Schema.String.pipe(Schema.optional),
+    items: Schema.Array(ItemSchema),
+  });
+
+  const onResponse = Effect.fn(function* (lastResponse: Response.Response) {
+    const payload = yield* Response.readJsonWithSchema(lastResponse, PayloadSchema);
+
+    const nextToken = Option.fromNullable(payload.nextToken);
+    const nextRequest = nextToken.pipe(
+      Option.map((token) => Request.setUrlSearchParam(request, 'token', token))
+    );
+
+    return {
+      pageEmission: payload.items,
+      nextRequest,
+    };
+  });
+
+  const mockFetch = Fetch.Fetch.of((_req: Request.Request) =>
+    Effect.succeed(
+      Response.unsafeMake({
+        ok: true,
+        status: 200,
+        statusText: '200 OK',
+        type: 'default',
+        url: 'https://example.com',
+        body: `{"items":[{"id":1,"name":"John"}]}`,
+      })
+    )
+  );
+
+  const _mockLayer = Layer.succeed(Fetch.Fetch, mockFetch);
+
+  test('dualApi', () => {
+    const a = Fetch.paginatedFetchStream(request, onResponse);
+    const b = Fetch.paginatedFetchStream(onResponse)(request);
+
+    // Streams are not directly comparable, only verify types match
+    expectTypeOf(a).toEqualTypeOf(b);
+  });
+});

--- a/packages/fx-fetch/src/Request/deleteHeader.test.ts
+++ b/packages/fx-fetch/src/Request/deleteHeader.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, expectTypeOf, test } from 'vitest';
 import * as Request from './index';
 
 describe('Request.deleteHeader', () => {
-  test('dual api', () => {
+  test('dual api without value (deletes all)', () => {
+    const headerName = 'Authorization';
     const request = Request.unsafeMake({
       url: 'https://example.com',
-      headers: { Authorization: 'Bearer token' },
+      headers: { [headerName]: 'Bearer token' },
     });
-    const headerName = 'Authorization';
 
     // Data-first form: deleteHeader(request, name)
     const a = Request.deleteHeader(request, headerName);
@@ -16,6 +16,25 @@ describe('Request.deleteHeader', () => {
     const b = Request.deleteHeader(headerName)(request);
 
     expect(a).toEqual(b);
+    expect(a.headers).toEqual(new Map());
+    expectTypeOf(a).toEqualTypeOf(b);
+  });
+
+  test('dual api with value (deletes specific)', () => {
+    const headerName = 'X-Custom-Header';
+    const request = Request.unsafeMake({
+      url: 'https://example.com',
+      headers: [[headerName, ['Value1', 'Value2']]],
+    });
+
+    // Data-first form: deleteHeader(request, name)
+    const a = Request.deleteHeader(request, headerName, 'Value1');
+
+    // Data-last form: deleteHeader(name)(request)
+    const b = Request.deleteHeader(headerName, 'Value1')(request);
+
+    expect(a).toEqual(b);
+    expect(a.headers).toEqual(new Map([['x-custom-header', ['Value2']]]));
     expectTypeOf(a).toEqualTypeOf(b);
   });
 });

--- a/packages/fx-fetch/src/Request/deleteHeader.ts
+++ b/packages/fx-fetch/src/Request/deleteHeader.ts
@@ -1,6 +1,7 @@
 import { dual } from 'effect/Function';
 import { headersIntermediateDelete } from '../utils/headersIntermediateDelete';
 import { requestToRequestIntermediate } from './inputToRequestIntermediate';
+import { isRequest } from './isRequest';
 import { makeFromRequestIntermediate } from './makeFromRequestIntermediate';
 import type { Request } from './Request';
 
@@ -63,4 +64,4 @@ export const deleteHeader: {
    * @since 0.1.0
    */
   (name: string, value?: string): (self: Request) => Request;
-} = dual(2, deleteHeaderFn);
+} = dual((args) => isRequest(args[0]), deleteHeaderFn);

--- a/packages/fx-fetch/src/Request/getHeader.test.ts
+++ b/packages/fx-fetch/src/Request/getHeader.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, expectTypeOf, test } from 'vitest';
+import * as Request from './index';
+
+describe('Request.getHeader', () => {
+  test('dual api', () => {
+    const request = Request.unsafeMake({
+      url: 'https://example.com',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    // Data-first form: getHeader(request, name)
+    const a = Request.getHeader(request, 'Authorization');
+
+    // Data-last form: getHeader(name)(request)
+    const b = Request.getHeader('Authorization')(request);
+
+    expect(a).toEqual(b);
+    expectTypeOf(a).toEqualTypeOf(b);
+  });
+});

--- a/packages/fx-fetch/src/Request/readJsonWithSchema.test.ts
+++ b/packages/fx-fetch/src/Request/readJsonWithSchema.test.ts
@@ -1,0 +1,26 @@
+import { Effect, Exit, Schema } from 'effect';
+import { describe, expect, expectTypeOf, test } from 'vitest';
+import * as Request from '.';
+
+describe('Request.readJsonWithSchema', () => {
+  const request = Request.unsafeMake({
+    url: 'https://example.com',
+    body: `{"name":"John","age":30}`,
+  });
+
+  const schema = Schema.Struct({
+    name: Schema.String,
+    age: Schema.Int,
+  });
+
+  test('dualApi', async () => {
+    const a = await Request.readJsonWithSchema(request, schema).pipe(Effect.runPromiseExit);
+    const b = await Request.readJsonWithSchema(schema)(request).pipe(Effect.runPromiseExit);
+
+    const expectedParsedValue = { name: 'John', age: 30 };
+
+    expect(a).toEqual(b);
+    expect(a).toEqual(Exit.succeed(expectedParsedValue));
+    expectTypeOf(a).toEqualTypeOf(b);
+  });
+});

--- a/packages/fx-fetch/src/Request/setUrlSearchParam.test.ts
+++ b/packages/fx-fetch/src/Request/setUrlSearchParam.test.ts
@@ -1,18 +1,33 @@
-import { expect, test } from 'vitest';
+import { describe, expect, expectTypeOf, test } from 'vitest';
 import * as Url from '../Url/index';
 import * as Request from './index';
 
-test('Request.setUrlSearchParam', () => {
-  const urlString = Request.unsafeMake({ url: 'https://example.com' }).pipe(
-    Request.setUrlSearchParam('page', '1'),
-    Request.setUrlSearchParam('limit', 20),
-    Request.setUrlSearchParam('limit2', 10),
-    Request.setUrlSearchParam('filter', ['active', 'new']),
-    Request.setUrlSearchParam('empty', ''),
-    Request.setUrlSearchParam('limit2', undefined),
-    Request.getUrl,
-    Url.format
-  );
+describe('Request.setUrlSearchParam', () => {
+  test('Request.setUrlSearchParam', () => {
+    const urlString = Request.unsafeMake({ url: 'https://example.com' }).pipe(
+      Request.setUrlSearchParam('page', '1'),
+      Request.setUrlSearchParam('limit', 20),
+      Request.setUrlSearchParam('limit2', 10),
+      Request.setUrlSearchParam('filter', ['active', 'new']),
+      Request.setUrlSearchParam('empty', ''),
+      Request.setUrlSearchParam('limit2', undefined),
+      Request.getUrl,
+      Url.format
+    );
 
-  expect(urlString).toBe('https://example.com?page=1&limit=20&filter=active&filter=new&empty=');
+    expect(urlString).toBe('https://example.com?page=1&limit=20&filter=active&filter=new&empty=');
+  });
+
+  test('dual api', () => {
+    const request = Request.unsafeMake({ url: 'https://example.com' });
+
+    // Data-first form: setUrlSearchParam(request, key, value)
+    const a = Request.setUrlSearchParam(request, 'page', '1');
+
+    // Data-last form: setUrlSearchParam(key, value)(request)
+    const b = Request.setUrlSearchParam('page', '1')(request);
+
+    expect(a).toEqual(b);
+    expectTypeOf(a).toEqualTypeOf(b);
+  });
 });

--- a/packages/fx-fetch/src/Request/unsafeSetUrl.test.ts
+++ b/packages/fx-fetch/src/Request/unsafeSetUrl.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, expectTypeOf, test } from 'vitest';
+import * as Request from './index';
+
+describe('Request.unsafeSetUrl', () => {
+  test('dual api', () => {
+    const request = Request.unsafeMake({ url: 'https://example.com' });
+    const newUrl = 'https://newdomain.com';
+
+    // Data-first form: unsafeSetUrl(request, url)
+    const a = Request.unsafeSetUrl(request, newUrl);
+
+    // Data-last form: unsafeSetUrl(url)(request)
+    const b = Request.unsafeSetUrl(newUrl)(request);
+
+    expect(a).toEqual(b);
+    expectTypeOf(a).toEqualTypeOf(b);
+  });
+});

--- a/packages/fx-fetch/src/Response/deleteHeader.test.ts
+++ b/packages/fx-fetch/src/Response/deleteHeader.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, expectTypeOf, test } from 'vitest';
 import * as Response from './index';
 
 describe('Response.deleteHeader', () => {
-  test('dual api', () => {
+  test('dual api with optional value', () => {
     const response = Response.unsafeMake({
       status: 200,
       statusText: '200 OK',
@@ -25,6 +25,35 @@ describe('Response.deleteHeader', () => {
     const b = Response.deleteHeader(headerName)(response);
 
     expect(a).toEqual(b);
+    expect(a.headers).toEqual(
+      new Map([
+        ['content-type', ['application/json']],
+        ['x-custom-header', ['value']],
+      ])
+    );
+    expectTypeOf(a).toEqualTypeOf(b);
+  });
+
+  test('dual api without optional value', () => {
+    const response = Response.unsafeMake({
+      status: 200,
+      statusText: '200 OK',
+      type: 'default',
+      url: 'https://example.com',
+      body: 'Test body',
+      headers: [['X-Custom-Header', ['Value1', 'Value2']]],
+    });
+
+    const headerName = 'X-Custom-Header';
+
+    // Data-first form: deleteHeader(response, name, value)
+    const a = Response.deleteHeader(response, headerName, 'Value1');
+
+    // Data-last form: deleteHeader(name, value)(response)
+    const b = Response.deleteHeader(headerName, 'Value1')(response);
+
+    expect(a).toEqual(b);
+    expect(a.headers).toEqual(new Map([['x-custom-header', ['Value2']]]));
     expectTypeOf(a).toEqualTypeOf(b);
   });
 });

--- a/packages/fx-fetch/src/Response/deleteHeader.ts
+++ b/packages/fx-fetch/src/Response/deleteHeader.ts
@@ -1,6 +1,7 @@
 import { dual } from 'effect/Function';
 import { headersIntermediateDelete } from '../utils/headersIntermediateDelete';
 import { responseToResponseIntermediate } from './inputToResponseIntermediate';
+import { isResponse } from './isResponse';
 import { makeFromResponseIntermediate } from './makeFromResponseIntermediate';
 import type { Response } from './Response';
 
@@ -63,4 +64,4 @@ export const deleteHeader: {
    * @since 0.1.0
    */
   (name: string, value?: string): (self: Response) => Response;
-} = dual(2, deleteHeaderFn);
+} = dual((args) => isResponse(args[0]), deleteHeaderFn);

--- a/packages/fx-fetch/src/Response/getHeader.test.ts
+++ b/packages/fx-fetch/src/Response/getHeader.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, expectTypeOf, test } from 'vitest';
+import * as Response from './index';
+
+describe('Response.getHeader', () => {
+  test('dual api', () => {
+    const response = Response.unsafeMake({
+      ok: true,
+      status: 200,
+      statusText: '200 OK',
+      type: 'default',
+      url: 'https://example.com',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    // Data-first form: getHeader(response, name)
+    const a = Response.getHeader(response, 'Authorization');
+
+    // Data-last form: getHeader(name)(response)
+    const b = Response.getHeader('Authorization')(response);
+
+    expect(a).toEqual(b);
+    expectTypeOf(a).toEqualTypeOf(b);
+  });
+});

--- a/packages/fx-fetch/src/Url/deleteSearchParam.test.ts
+++ b/packages/fx-fetch/src/Url/deleteSearchParam.test.ts
@@ -2,31 +2,34 @@ import { describe, expect, expectTypeOf, test } from 'vitest';
 import * as Url from './index';
 
 describe('Url.deleteSearchParam', () => {
-  test('dual api', () => {
+  test('dual api without value (deletes all)', () => {
     const url = Url.unsafeMake('https://example.com?page=1&limit=10');
     const key = 'page';
 
-    // Dual API: Data-first
-    const a = Url.deleteSearchParam(url, key, undefined);
+    // Data-first form: deleteSearchParam(url, key)
+    const a = Url.deleteSearchParam(url, key);
 
-    // Dual API: Data-last
-    const b = Url.deleteSearchParam(key, undefined)(url);
+    // Data-last form: deleteSearchParam(key)(url)
+    const b = Url.deleteSearchParam(key)(url);
 
     expect(a).toEqual(b);
+    expect(Url.format(a)).toBe('https://example.com?limit=10');
     expectTypeOf(a).toEqualTypeOf(b);
   });
 
-  test('deletes all values for a given key when no value is provided', () => {
+  test('dual api with value (deletes specific)', () => {
     const url = Url.unsafeMake('https://example.com?tag=new&tag=sale&tag=active');
-    const updatedUrl = Url.deleteSearchParam(url, 'tag', undefined);
+    const key = 'tag';
+    const value = 'sale';
 
-    expect(Url.format(updatedUrl)).toBe('https://example.com');
-  });
+    // Data-first form: deleteSearchParam(url, key, value)
+    const a = Url.deleteSearchParam(url, key, value);
 
-  test('deletes only the specified value for a given key', () => {
-    const url = Url.unsafeMake('https://example.com?tag=new&tag=sale&tag=active');
-    const updatedUrl = Url.deleteSearchParam(url, 'tag', 'sale');
+    // Data-last form: deleteSearchParam(key, value)(url)
+    const b = Url.deleteSearchParam(key, value)(url);
 
-    expect(Url.format(updatedUrl)).toBe('https://example.com?tag=new&tag=active');
+    expect(a).toEqual(b);
+    expect(Url.format(a)).toBe('https://example.com?tag=new&tag=active');
+    expectTypeOf(a).toEqualTypeOf(b);
   });
 });

--- a/packages/fx-fetch/src/Url/deleteSearchParam.ts
+++ b/packages/fx-fetch/src/Url/deleteSearchParam.ts
@@ -1,11 +1,12 @@
 import { dual } from 'effect/Function';
 import type { Url } from '../Url';
 import { urlToUrlIntermediate } from './inputToUrlIntermediate';
+import { isUrl } from './isUrl';
 import { makeFromUrlIntermediate } from './makeFromUrlIntermediate';
 import type { SearchParamValueInput } from './SearchParamValueInput';
 import { inputToSearchParamValueIntermediate } from './SearchParamValueIntermediate';
 
-function deleteSearchParamFn(url: Url, key: string, value: SearchParamValueInput): Url {
+function deleteSearchParamFn(url: Url, key: string, value?: SearchParamValueInput): Url {
   const urlIntermediate = urlToUrlIntermediate(url);
   const normalizedValues = inputToSearchParamValueIntermediate(value);
 
@@ -60,7 +61,7 @@ function deleteSearchParamFn(url: Url, key: string, value: SearchParamValueInput
  *
  * // Remove all 'tag' parameters
  * url.pipe(
- *   Url.deleteSearchParam('tag', undefined),
+ *   Url.deleteSearchParam('tag'),
  *   Url.format // 'https://example.com'
  * );
  * ```
@@ -94,7 +95,7 @@ export const deleteSearchParam: {
    *
    * // Remove all 'tag' parameters
    * url.pipe(
-   *   Url.deleteSearchParam('tag', undefined),
+   *   Url.deleteSearchParam('tag'),
    *   Url.format // 'https://example.com'
    * );
    * ```
@@ -102,7 +103,7 @@ export const deleteSearchParam: {
    * @category Combinators
    * @since 0.1.0
    */
-  (url: Url, key: string, value: SearchParamValueInput): Url;
+  (url: Url, key: string, value?: SearchParamValueInput): Url;
   /**
    * Deletes search parameters from a Url.
    * If a value is provided, only that value is removed; otherwise, all values for the key are removed.
@@ -128,7 +129,7 @@ export const deleteSearchParam: {
    *
    * // Remove all 'tag' parameters
    * url.pipe(
-   *   Url.deleteSearchParam('tag', undefined),
+   *   Url.deleteSearchParam('tag'),
    *   Url.format // 'https://example.com'
    * );
    * ```
@@ -136,5 +137,5 @@ export const deleteSearchParam: {
    * @category Combinators
    * @since 0.1.0
    */
-  (key: string, value: SearchParamValueInput): (url: Url) => Url;
-} = dual(3, deleteSearchParamFn);
+  (key: string, value?: SearchParamValueInput): (url: Url) => Url;
+} = dual((args) => isUrl(args[0]), deleteSearchParamFn);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Add comprehensive test coverage for dual API patterns and coding style guidelines

## Changes

- **Documentation**: Added `.claude/skills/conding-style/SKILL.md` with TypeScript formatting and style guidelines for the fx-fetch project

- **Test Coverage**: Added 11 new test files and modified 1 existing test to validate dual API usage across the package:
  - Fetch API tests: `fetchJsonWithSchema.test.ts`, `fetchStream.test.ts`, `paginatedFetch.test.ts`, `paginatedFetchStream.test.ts`
  - Request API tests: `getHeader.test.ts`, `readJsonWithSchema.test.ts`, `readStream.test.ts`, `setUrlSearchParam.test.ts`, `unsafeSetUrl.test.ts`
  - Response API tests: `getHeader.test.ts`, `readStream.test.ts`

All tests verify that functions support both data-first and data-last (curried) invocation styles with identical results and type alignment.

**Total**: +332 lines of tests and documentation, -13 lines modified in existing test

<!-- end of auto-generated comment: release notes by coderabbit.ai -->