### PR TITLE
11/implement fetch middleware

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm fmt:*)",
+      "Bash(pnpm fmt:write:*)",
+      "Bash(pnpm check:*)",
+      "Bash(pnpm test:*)",
+      "Bash(pnpm validate:*)"
+    ]
+  },
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/nx.json
+++ b/nx.json
@@ -65,14 +65,20 @@
         "{projectRoot}/dist"
       ]
     },
-    "fmt": {},
-    "fmt:write": {},
+    "fmt": {
+      "cache": true
+    },
+    "fmt:write": {
+      "cache": false
+    },
     "validate": {
+      "cache": true,
       "dependsOn": [
         "^validate"
       ]
     },
     "test": {
+      "cache": true,
       "dependsOn": [
         "^test",
         "validate",

--- a/packages/fx-fetch/src/Fetch/Fetch.ts
+++ b/packages/fx-fetch/src/Fetch/Fetch.ts
@@ -4,20 +4,37 @@ import type { Request } from '../Request';
 import { NotOkError, type Response } from '../Response';
 import { AbortError, FetchError, NotAllowedError } from './errors';
 
+export namespace Fetch {
+  /**
+   * Type alias for the successful response type of the Fetch service.
+   * @since 1.2.0
+   * @category Models
+   */
+  export type SuccessType = Response;
+
+  /**
+   * Type alias for the failure response type of the Fetch service.
+   * @since 1.2.0
+   * @category Models
+   */
+  export type ErrorType = AbortError | FetchError | NotAllowedError | NotOkError;
+}
+
 /**
  * Fetch service for making or mocking HTTP requests.
  *
  * @example
- * ```
- * import { Fetch } from "fx-fetch";
+ * ```ts
+ * import { Effect } from 'effect';
+ * import { Fetch, Request } from 'fx-fetch';
  *
  * Effect.gen(function* () {
- *   const request = new Request('https://example.com');
+ *   const request = Request.unsafeMake({ url: 'https://example.com' });
  *
  *   const fetch = yield* Fetch.Fetch; // ◀︎── Get the Fetch service
  *   const response = yield* fetch(request);
  * }).pipe(
- *   Effect.provideService(Fetch.Fetch, Fetch.layer), // ◀︎── Provide built-in Fetch service
+ *   Effect.provide(Fetch.layer), // ◀︎── Provide built-in Fetch layer
  *   Effect.runPromise
  * );
  * ```
@@ -27,7 +44,5 @@ import { AbortError, FetchError, NotAllowedError } from './errors';
  */
 export class Fetch extends Tag('fx-fetch/Fetch')<
   Fetch,
-  (
-    request: Request
-  ) => Effect<Response, AbortError | FetchError | NotAllowedError | NotOkError, never>
+  (request: Request) => Effect<Fetch.SuccessType, Fetch.ErrorType, never>
 >() {}

--- a/packages/fx-fetch/src/Fetch/FetchLive.ts
+++ b/packages/fx-fetch/src/Fetch/FetchLive.ts
@@ -1,61 +1,38 @@
-import { RuntimeException } from 'effect/Cause';
-import { dieMessage, flatMap, map, succeed, tryPromise } from 'effect/Effect';
-import { match } from 'effect/Option';
-import { type Request, toJsRequestPromise } from '../Request';
-import { ensureOk, make } from '../Response';
-import { getErrorMessage } from '../utils/getErrorMessage';
-import { AbortError, FetchError, NotAllowedError } from './errors';
+import { flatMap } from 'effect/Effect';
+import { type Request } from '../Request';
+import { ensureOk } from '../Response';
+import { executeFetch } from './executeFetch';
 import type { Type } from './Type';
 
-// TODO: Add examples
-
 /**
- * Fetch a request and handle the response.
+ * Live implementation of the Fetch service that performs actual HTTP requests.
  *
- * @category Layers
+ * @example
+ * ```ts
+ * import { Effect } from 'effect';
+ * import { Fetch, Request, Response } from 'fx-fetch';
+ *
+ * //       ┌─── Effect.Effect<
+ * //       │      Response.Response,
+ * //       │      | Fetch.FetchError
+ * //       │      | Fetch.AbortError
+ * //       │      | Fetch.NotAllowedError
+ * //       │      | Response.NotOkError,
+ * //       │      never
+ * //       │    >
+ * //       ▼
+ * const program = Effect.gen(function* () {
+ *   const request = Request.unsafeMake({ url: 'https://example.com' });
+ *
+ *   //       ┌─── Response.Response
+ *   //       ▼
+ *   const response = yield* Fetch.FetchLive(request);
+ *
+ *   return response;
+ * });
+ * ```
+ *
+ * @category Services
  * @since 0.1.0
  */
-export const FetchLive: Type = (request: Request) =>
-  tryPromise({
-    try: async (signal) => {
-      const jsRequest = await toJsRequestPromise(request, { signal });
-      return await globalThis.fetch(jsRequest);
-    },
-    catch(error) {
-      if (error instanceof TypeError) {
-        return new FetchError({
-          message: error.message,
-          cause: error,
-        });
-      }
-
-      if (typeof error === 'object' && error !== null && 'name' in error) {
-        if (error.name === 'AbortError') {
-          return new AbortError({
-            message: getErrorMessage(error, 'Http request aborted'),
-            cause: error,
-          });
-        }
-
-        if (error.name === 'NotAllowedError') {
-          return new NotAllowedError({
-            message: getErrorMessage(error, 'Http request not allowed'),
-            cause: error,
-          });
-        }
-      }
-
-      throw new RuntimeException(
-        getErrorMessage(error, 'Unknown error occurred during fetch request')
-      );
-    },
-  }).pipe(
-    map(make),
-    flatMap(
-      match({
-        onSome: succeed,
-        onNone: () => dieMessage('Failed to create Response from fetch response'),
-      })
-    ),
-    flatMap(ensureOk)
-  );
+export const FetchLive: Type = (request: Request) => executeFetch(request).pipe(flatMap(ensureOk));

--- a/packages/fx-fetch/src/Fetch/executeFetch.ts
+++ b/packages/fx-fetch/src/Fetch/executeFetch.ts
@@ -1,0 +1,68 @@
+import { RuntimeException } from 'effect/Cause';
+import {
+  dieMessage,
+  ensureErrorType,
+  ensureRequirementsType,
+  ensureSuccessType,
+  flatMap,
+  map,
+  succeed,
+  tryPromise,
+} from 'effect/Effect';
+import { match } from 'effect/Option';
+import { type Request, toJsRequestPromise } from '../Request';
+import { make as makeResponse, type Response } from '../Response';
+import { getErrorMessage } from '../utils/getErrorMessage';
+import { AbortError, FetchError, NotAllowedError } from './errors';
+
+/**
+ * Core implementation of fetch execution.
+ *
+ * @internal
+ */
+export const executeFetch = (request: Request) =>
+  tryPromise({
+    try: async (signal) => {
+      const jsRequest = await toJsRequestPromise(request, { signal });
+      return await globalThis.fetch(jsRequest);
+    },
+    catch(error) {
+      if (error instanceof TypeError) {
+        return new FetchError({
+          message: error.message,
+          cause: error,
+        });
+      }
+
+      if (typeof error === 'object' && error !== null && 'name' in error) {
+        if (error.name === 'AbortError') {
+          return new AbortError({
+            message: getErrorMessage(error, 'Http request aborted'),
+            cause: error,
+          });
+        }
+
+        if (error.name === 'NotAllowedError') {
+          return new NotAllowedError({
+            message: getErrorMessage(error, 'Http request not allowed'),
+            cause: error,
+          });
+        }
+      }
+
+      throw new RuntimeException(
+        getErrorMessage(error, 'Unknown error occurred during fetch request')
+      );
+    },
+  }).pipe(
+    map(makeResponse),
+    flatMap(
+      match({
+        onSome: succeed,
+        onNone: () => dieMessage('Failed to create Response from fetch response'),
+      })
+    ),
+    ensureSuccessType<Response>(),
+    ensureErrorType<AbortError | FetchError | NotAllowedError>(),
+    ensureRequirementsType<never>()
+  );

--- a/packages/fx-fetch/src/Fetch/index.ts
+++ b/packages/fx-fetch/src/Fetch/index.ts
@@ -12,6 +12,7 @@ export { fetchReadableStream } from './fetchReadableStream';
 export { fetchStream } from './fetchStream';
 export { fetchText } from './fetchText';
 export { layer } from './layer';
+export { makeMockLayer } from './makeMockLayer';
 export { paginatedFetch } from './paginatedFetch';
 export { paginatedFetchStream } from './paginatedFetchStream';
 export type { Type } from './Type';

--- a/packages/fx-fetch/src/Fetch/index.ts
+++ b/packages/fx-fetch/src/Fetch/index.ts
@@ -11,6 +11,7 @@ export { fetchJsonWithSchema } from './fetchJsonWithSchema';
 export { fetchReadableStream } from './fetchReadableStream';
 export { fetchStream } from './fetchStream';
 export { fetchText } from './fetchText';
+export { layer } from './layer';
 export { paginatedFetch } from './paginatedFetch';
 export { paginatedFetchStream } from './paginatedFetchStream';
 export type { Type } from './Type';

--- a/packages/fx-fetch/src/Fetch/index.ts
+++ b/packages/fx-fetch/src/Fetch/index.ts
@@ -12,6 +12,7 @@ export { fetchReadableStream } from './fetchReadableStream';
 export { fetchStream } from './fetchStream';
 export { fetchText } from './fetchText';
 export { layer } from './layer';
+export { makeMiddlewareLayer } from './makeMiddlewareLayer';
 export { makeMockLayer } from './makeMockLayer';
 export { paginatedFetch } from './paginatedFetch';
 export { paginatedFetchStream } from './paginatedFetchStream';

--- a/packages/fx-fetch/src/Fetch/layer.test.ts
+++ b/packages/fx-fetch/src/Fetch/layer.test.ts
@@ -1,0 +1,21 @@
+import { Effect, Exit, Layer } from 'effect';
+import { describe, expect, expectTypeOf, test } from 'vitest';
+import { Fetch } from './Fetch';
+import { layer } from './layer';
+
+describe('Fetch.layer', () => {
+  test('provides Fetch service', async () => {
+    const program = Effect.gen(function* () {
+      const fetch = yield* Fetch;
+      return fetch;
+    });
+
+    const result = await program.pipe(Effect.provide(layer), Effect.runPromiseExit);
+
+    expect(Exit.isSuccess(result)).toBe(true);
+  });
+
+  test('layer type', () => {
+    expectTypeOf(layer).toEqualTypeOf<Layer.Layer<Fetch>>();
+  });
+});

--- a/packages/fx-fetch/src/Fetch/layer.ts
+++ b/packages/fx-fetch/src/Fetch/layer.ts
@@ -1,0 +1,29 @@
+import { type Layer, succeed as layerSucceed } from 'effect/Layer';
+import { Fetch } from './Fetch';
+import { FetchLive } from './FetchLive';
+
+/**
+ * Fetch layer providing the live implementation.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from 'effect';
+ * import { Fetch, Request } from 'fx-fetch';
+ *
+ * const program = Effect.gen(function* () {
+ *   const request = Request.unsafeMake({ url: 'https://example.com' });
+ *   const response = yield* Fetch.fetch(request);
+ *
+ *   return response;
+ * });
+ *
+ * program.pipe(
+ *   Effect.provide(Fetch.layer), // ◀︎── Provide Fetch layer
+ *   Effect.runPromise
+ * );
+ * ```
+ *
+ * @category Layers
+ * @since 1.2.0
+ */
+export const layer: Layer<Fetch, never, never> = layerSucceed(Fetch, FetchLive);

--- a/packages/fx-fetch/src/Fetch/makeMiddlewareLayer.test.ts
+++ b/packages/fx-fetch/src/Fetch/makeMiddlewareLayer.test.ts
@@ -1,0 +1,393 @@
+import { Context, Effect, Exit, Layer } from 'effect';
+import { afterEach, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
+import { Fetch, Request } from '../index';
+import { makeMiddlewareLayer } from './makeMiddlewareLayer';
+
+describe('Fetch.makeMiddlewareLayer', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(mockFetch);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const request = Request.unsafeMake({ url: 'https://example.com' });
+
+  // Type Safety Tests
+  describe('type safety', () => {
+    test('returns Layer<Fetch, never, never> with empty options', () => {
+      const layer = makeMiddlewareLayer({});
+
+      expectTypeOf(layer).toEqualTypeOf<Layer.Layer<Fetch.Fetch, never, never>>();
+    });
+
+    test('returns Layer with R1 requirement when mapRequest has requirements', () => {
+      class Config extends Context.Tag('Config')<Config, { apiKey: string }>() {}
+
+      const layer = makeMiddlewareLayer({
+        mapRequest: (req) =>
+          Effect.gen(function* () {
+            const config = yield* Config;
+            return Request.appendHeaders(req, { 'X-API-Key': config.apiKey });
+          }),
+      });
+
+      expectTypeOf(layer).toEqualTypeOf<Layer.Layer<Fetch.Fetch, never, Config>>();
+    });
+
+    test('returns Layer with R2 requirement when mapResponse has requirements', () => {
+      class Logger extends Context.Tag('Logger')<Logger, { log: (msg: string) => void }>() {}
+
+      const layer = makeMiddlewareLayer({
+        mapResponse: (response) =>
+          Effect.gen(function* () {
+            const logger = yield* Logger;
+            logger.log(`Response status: ${response.status}`);
+            return response;
+          }),
+      });
+
+      expectTypeOf(layer).toEqualTypeOf<Layer.Layer<Fetch.Fetch, never, Logger>>();
+    });
+
+    test('returns Layer with R1 | R2 requirements when both have requirements', () => {
+      class Config extends Context.Tag('Config')<Config, { apiKey: string }>() {}
+      class Logger extends Context.Tag('Logger')<Logger, { log: (msg: string) => void }>() {}
+
+      const layer = makeMiddlewareLayer({
+        mapRequest: (req) =>
+          Effect.gen(function* () {
+            const config = yield* Config;
+            return Request.appendHeaders(req, { 'X-API-Key': config.apiKey });
+          }),
+        mapResponse: (response) =>
+          Effect.gen(function* () {
+            const logger = yield* Logger;
+            logger.log(`Response status: ${response.status}`);
+            return response;
+          }),
+      });
+
+      expectTypeOf(layer).toEqualTypeOf<Layer.Layer<Fetch.Fetch, never, Config | Logger>>();
+    });
+  });
+
+  // Basic Functionality Tests
+  describe('basic functionality', () => {
+    test('empty options passes request through to fetch', async () => {
+      mockFetch.mockResolvedValue(new globalThis.Response('OK', { status: 200 }));
+
+      const middlewareLayer = makeMiddlewareLayer({});
+
+      const result = await Effect.gen(function* () {
+        const fetch = yield* Fetch.Fetch;
+        return yield* fetch(request);
+      }).pipe(Effect.provide(middlewareLayer), Effect.runPromiseExit);
+
+      expect(Exit.isSuccess(result)).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('fetch is called with the provided request URL', async () => {
+      mockFetch.mockResolvedValue(new globalThis.Response('OK', { status: 200 }));
+
+      const middlewareLayer = makeMiddlewareLayer({});
+      const customRequest = Request.unsafeMake({ url: 'https://api.example.com/users' });
+
+      await Effect.gen(function* () {
+        const fetch = yield* Fetch.Fetch;
+        return yield* fetch(customRequest);
+      }).pipe(Effect.provide(middlewareLayer), Effect.runPromiseExit);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const calledRequest = mockFetch.mock.calls[0][0] as globalThis.Request;
+      expect(calledRequest.url).toBe('https://api.example.com/users');
+    });
+  });
+
+  // mapRequest Transformation Tests
+  describe('mapRequest transformation', () => {
+    test('transforms request before it reaches fetch', async () => {
+      mockFetch.mockResolvedValue(new globalThis.Response('OK', { status: 200 }));
+
+      const middlewareLayer = makeMiddlewareLayer({
+        mapRequest: (req) => Effect.succeed(Request.appendHeaders(req, { 'X-Custom': 'value' })),
+      });
+
+      await Effect.gen(function* () {
+        const fetch = yield* Fetch.Fetch;
+        return yield* fetch(request);
+      }).pipe(Effect.provide(middlewareLayer), Effect.runPromiseExit);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const calledRequest = mockFetch.mock.calls[0][0] as globalThis.Request;
+      expect(calledRequest.headers.get('X-Custom')).toBe('value');
+    });
+
+    test('can add authorization header via middleware', async () => {
+      mockFetch.mockResolvedValue(new globalThis.Response('OK', { status: 200 }));
+
+      const middlewareLayer = makeMiddlewareLayer({
+        mapRequest: (req) =>
+          Effect.succeed(Request.appendHeaders(req, { Authorization: 'Bearer token123' })),
+      });
+
+      await Effect.gen(function* () {
+        const fetch = yield* Fetch.Fetch;
+        return yield* fetch(request);
+      }).pipe(Effect.provide(middlewareLayer), Effect.runPromiseExit);
+
+      const calledRequest = mockFetch.mock.calls[0][0] as globalThis.Request;
+      expect(calledRequest.headers.get('Authorization')).toBe('Bearer token123');
+    });
+  });
+
+  // mapResponse Transformation Tests
+  describe('mapResponse transformation', () => {
+    test('receives response from fetch', async () => {
+      mockFetch.mockResolvedValue(new globalThis.Response('Hello World', { status: 200 }));
+
+      let capturedStatus: number | undefined;
+      const middlewareLayer = makeMiddlewareLayer({
+        mapResponse: (response) => {
+          capturedStatus = response.status;
+          return Effect.succeed(response);
+        },
+      });
+
+      await Effect.gen(function* () {
+        const fetch = yield* Fetch.Fetch;
+        return yield* fetch(request);
+      }).pipe(Effect.provide(middlewareLayer), Effect.runPromiseExit);
+
+      expect(capturedStatus).toBe(200);
+    });
+
+    test('ensureOk is applied after mapResponse', async () => {
+      mockFetch.mockResolvedValue(new globalThis.Response('Not Found', { status: 404 }));
+
+      let mapResponseCalled = false;
+      const middlewareLayer = makeMiddlewareLayer({
+        mapResponse: (response) => {
+          mapResponseCalled = true;
+          return Effect.succeed(response);
+        },
+      });
+
+      const result = await Effect.gen(function* () {
+        const fetch = yield* Fetch.Fetch;
+        return yield* fetch(request);
+      }).pipe(Effect.provide(middlewareLayer), Effect.runPromiseExit);
+
+      expect(mapResponseCalled).toBe(true);
+      expect(Exit.isFailure(result)).toBe(true);
+
+      if (Exit.isFailure(result)) {
+        const error = result.cause.pipe((cause) =>
+          cause._tag === 'Fail' ? cause.error : undefined
+        );
+        expect(error?._tag).toBe('NotOkError');
+      }
+    });
+  });
+
+  // Combined mapRequest + mapResponse Tests
+  describe('combined mapRequest and mapResponse', () => {
+    test('both transformations work together', async () => {
+      mockFetch.mockResolvedValue(new globalThis.Response('OK', { status: 200 }));
+
+      let requestTransformed = false;
+      let responseTransformed = false;
+
+      const middlewareLayer = makeMiddlewareLayer({
+        mapRequest: (req) => {
+          requestTransformed = true;
+          return Effect.succeed(Request.appendHeaders(req, { 'X-Request-Id': '123' }));
+        },
+        mapResponse: (response) => {
+          responseTransformed = true;
+          return Effect.succeed(response);
+        },
+      });
+
+      const result = await Effect.gen(function* () {
+        const fetch = yield* Fetch.Fetch;
+        return yield* fetch(request);
+      }).pipe(Effect.provide(middlewareLayer), Effect.runPromiseExit);
+
+      expect(Exit.isSuccess(result)).toBe(true);
+      expect(requestTransformed).toBe(true);
+      expect(responseTransformed).toBe(true);
+
+      const calledRequest = mockFetch.mock.calls[0][0] as globalThis.Request;
+      expect(calledRequest.headers.get('X-Request-Id')).toBe('123');
+    });
+
+    test('execution order: mapRequest → fetch → mapResponse → ensureOk', async () => {
+      const executionOrder: string[] = [];
+
+      mockFetch.mockImplementation(() => {
+        executionOrder.push('fetch');
+        return new globalThis.Response('OK', { status: 200 });
+      });
+
+      const middlewareLayer = makeMiddlewareLayer({
+        mapRequest: (req) => {
+          executionOrder.push('mapRequest');
+          return Effect.succeed(req);
+        },
+        mapResponse: (response) => {
+          executionOrder.push('mapResponse');
+          return Effect.succeed(response);
+        },
+      });
+
+      await Effect.gen(function* () {
+        const fetch = yield* Fetch.Fetch;
+        return yield* fetch(request);
+      }).pipe(Effect.provide(middlewareLayer), Effect.runPromiseExit);
+
+      expect(executionOrder).toEqual(['mapRequest', 'fetch', 'mapResponse']);
+    });
+  });
+
+  // Error Handling Tests
+  describe('error handling', () => {
+    test('non-2xx response causes NotOkError', async () => {
+      mockFetch.mockResolvedValue(new globalThis.Response('Server Error', { status: 500 }));
+
+      const middlewareLayer = makeMiddlewareLayer({});
+
+      const result = await Effect.gen(function* () {
+        const fetch = yield* Fetch.Fetch;
+        return yield* fetch(request);
+      }).pipe(Effect.provide(middlewareLayer), Effect.runPromiseExit);
+
+      expect(Exit.isFailure(result)).toBe(true);
+
+      if (Exit.isFailure(result)) {
+        const error = result.cause.pipe((cause) =>
+          cause._tag === 'Fail' ? cause.error : undefined
+        );
+        expect(error?._tag).toBe('NotOkError');
+      }
+    });
+
+    test('fetch errors propagate correctly', async () => {
+      mockFetch.mockRejectedValue(new TypeError('Network error'));
+
+      const middlewareLayer = makeMiddlewareLayer({});
+
+      const result = await Effect.gen(function* () {
+        const fetch = yield* Fetch.Fetch;
+        return yield* fetch(request);
+      }).pipe(Effect.provide(middlewareLayer), Effect.runPromiseExit);
+
+      expect(Exit.isFailure(result)).toBe(true);
+
+      if (Exit.isFailure(result)) {
+        const error = result.cause.pipe((cause) =>
+          cause._tag === 'Fail' ? cause.error : undefined
+        );
+        expect(error?._tag).toBe('FetchError');
+      }
+    });
+  });
+
+  test('middleware can access required services in mapRequest', async () => {
+    mockFetch.mockResolvedValue(new globalThis.Response('OK', { status: 200 }));
+
+    class Config extends Context.Tag('Config')<Config, { apiKey: string }>() {}
+
+    const middlewareLayer = makeMiddlewareLayer({
+      mapRequest: (req) =>
+        Effect.gen(function* () {
+          const config = yield* Config;
+          return Request.appendHeaders(req, { 'X-API-Key': config.apiKey });
+        }),
+    });
+
+    const configLayer = Layer.succeed(Config, { apiKey: 'secret-key-123' });
+
+    const testLayer = Layer.provideMerge(middlewareLayer, configLayer);
+
+    const result = await Effect.gen(function* () {
+      const fetch = yield* Fetch.Fetch;
+      return yield* fetch(request);
+    }).pipe(Effect.provide(testLayer), Effect.runPromiseExit);
+
+    expect(Exit.isSuccess(result)).toBe(true);
+
+    const calledRequest = mockFetch.mock.calls[0][0] as globalThis.Request;
+    expect(calledRequest.headers.get('X-API-Key')).toBe('secret-key-123');
+  });
+
+  test('middleware can access required services in mapResponse', async () => {
+    mockFetch.mockResolvedValue(new globalThis.Response('OK', { status: 200 }));
+
+    const logMessages: string[] = [];
+    class Logger extends Context.Tag('Logger')<Logger, { log: (msg: string) => void }>() {}
+
+    const middlewareLayer = makeMiddlewareLayer({
+      mapResponse: (response) =>
+        Effect.gen(function* () {
+          const logger = yield* Logger;
+          logger.log(`Response status: ${response.status}`);
+          return response;
+        }),
+    });
+
+    const loggerLayer = Layer.succeed(Logger, { log: (msg) => logMessages.push(msg) });
+    const testLayer = Layer.provideMerge(middlewareLayer, loggerLayer);
+
+    const result = await Effect.gen(function* () {
+      const fetch = yield* Fetch.Fetch;
+      return yield* fetch(request);
+    }).pipe(Effect.provide(testLayer), Effect.runPromiseExit);
+
+    expect(Exit.isSuccess(result)).toBe(true);
+    expect(logMessages).toEqual(['Response status: 200']);
+  });
+
+  test('combined requirements from both mapRequest and mapResponse', async () => {
+    mockFetch.mockResolvedValue(new globalThis.Response('OK', { status: 200 }));
+
+    class Config extends Context.Tag('Config')<Config, { apiKey: string }>() {}
+    class Logger extends Context.Tag('Logger')<Logger, { log: (msg: string) => void }>() {}
+
+    const logMessages: string[] = [];
+
+    const middlewareLayer = makeMiddlewareLayer({
+      mapRequest: (req) =>
+        Effect.gen(function* () {
+          const config = yield* Config;
+          return Request.appendHeaders(req, { 'X-API-Key': config.apiKey });
+        }),
+      mapResponse: (response) =>
+        Effect.gen(function* () {
+          const logger = yield* Logger;
+          logger.log(`Response status: ${response.status}`);
+          return response;
+        }),
+    });
+
+    const configLayer = Layer.succeed(Config, { apiKey: 'combined-key' });
+    const loggerLayer = Layer.succeed(Logger, { log: (msg) => logMessages.push(msg) });
+    const testLayer = Layer.provideMerge(middlewareLayer, Layer.merge(configLayer, loggerLayer));
+
+    const result = await Effect.gen(function* () {
+      const fetch = yield* Fetch.Fetch;
+      return yield* fetch(request);
+    }).pipe(Effect.provide(testLayer), Effect.runPromiseExit);
+
+    expect(Exit.isSuccess(result)).toBe(true);
+
+    const calledRequest = mockFetch.mock.calls[0][0] as globalThis.Request;
+    expect(calledRequest.headers.get('X-API-Key')).toBe('combined-key');
+    expect(logMessages).toEqual(['Response status: 200']);
+  });
+});

--- a/packages/fx-fetch/src/Fetch/makeMiddlewareLayer.ts
+++ b/packages/fx-fetch/src/Fetch/makeMiddlewareLayer.ts
@@ -1,0 +1,94 @@
+import { context, type Effect, flatMap, gen, provide, succeed } from 'effect/Effect';
+import { type Layer, effect as layerEffect } from 'effect/Layer';
+import type { Request } from '../Request';
+import { ensureOk, type Response } from '../Response';
+import { executeFetch } from './executeFetch';
+import { Fetch } from './Fetch';
+import type { Type } from './Type';
+
+type MiddlewareOptions<R1, R2> = {
+  readonly mapRequest?: (request: Request) => Effect<Request, never, R1>;
+  readonly mapResponse?: (response: Response) => Effect<Response, Fetch.ErrorType, R2>;
+};
+
+/**
+ * Creates a middleware Layer that allows customizing request and response handling.
+ *
+ * The middleware can transform requests before they are sent and responses after they are received.
+ * Both `mapRequest` and `mapResponse` are optional - if not provided, they pass through unchanged.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from 'effect';
+ * import { Fetch, Request } from 'fx-fetch';
+ *
+ * // Middleware that adds authorization header to all requests
+ * const authMiddlewareLayer = Fetch.makeMiddlewareLayer({
+ *   mapRequest: (request) =>
+ *     Effect.succeed(
+ *       Request.appendHeaders(request, { Authorization: 'Bearer token' })
+ *     ),
+ * });
+ *
+ * Effect.gen(function* () {
+ *   const request = Request.unsafeMake({ url: 'https://api.example.com/data' });
+ *   const response = yield* Fetch.fetch(request);
+ * }).pipe(
+ *   Effect.provide(authMiddlewareLayer), // ◀︎── Provide middleware layer
+ *   Effect.runPromise
+ * );
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { Context, Effect, Layer } from 'effect';
+ * import { Fetch, Request } from 'fx-fetch';
+ *
+ * // Service for configuration
+ * class Config extends Context.Tag('Config')<Config, { apiKey: string }>() {}
+ *
+ * // Middleware with requirements - the Layer properly tracks Config requirement
+ * const authMiddlewareLayer = Fetch.makeMiddlewareLayer({
+ *   mapRequest: (request) =>
+ *     Effect.gen(function* () {
+ *       const config = yield* Config;
+ *       return Request.appendHeaders(request, { 'X-API-Key': config.apiKey });
+ *     }),
+ * });
+ * // Type: Layer<Fetch, never, Config>
+ *
+ * Effect.gen(function* () {
+ *   const request = Request.unsafeMake({ url: 'https://api.example.com/data' });
+ *   const response = yield* Fetch.fetch(request);
+ * }).pipe(
+ *   Effect.provide(authMiddlewareLayer),
+ *   Effect.provide(Layer.succeed(Config, { apiKey: 'secret' })),
+ *   Effect.runPromise
+ * );
+ * ```
+ *
+ * @category Layers
+ * @since 1.2.0
+ */
+export const makeMiddlewareLayer = <R1 = never, R2 = never>(
+  options: MiddlewareOptions<R1, R2>
+): Layer<Fetch, never, R1 | R2> => {
+  const mapRequest = options.mapRequest ?? ((request: Request) => succeed(request));
+  const mapResponse = options.mapResponse ?? ((response: Response) => succeed(response));
+
+  const makeService = gen(function* () {
+    const ctx = yield* context<R1 | R2>();
+
+    const service: Type = (request: Request) =>
+      mapRequest(request).pipe(
+        flatMap(executeFetch),
+        flatMap(mapResponse),
+        flatMap(ensureOk),
+        provide(ctx)
+      );
+
+    return service;
+  });
+
+  return layerEffect(Fetch, makeService);
+};

--- a/packages/fx-fetch/src/Fetch/makeMockLayer.test.ts
+++ b/packages/fx-fetch/src/Fetch/makeMockLayer.test.ts
@@ -1,0 +1,121 @@
+import { Effect, Exit, Layer } from 'effect';
+import { describe, expect, expectTypeOf, test } from 'vitest';
+import * as Request from '../Request';
+import * as Response from '../Response';
+import * as Url from '../Url';
+import { AbortError } from './errors';
+import { Fetch } from './Fetch';
+import { makeMockLayer } from './makeMockLayer';
+
+describe('Fetch.makeMockLayer', () => {
+  const request = Request.unsafeMake({ url: 'https://example.com' });
+
+  test('returns Layer type', () => {
+    const mockLayer = makeMockLayer(() => Response.unsafeMake({ status: 200, ok: true }));
+
+    expectTypeOf(mockLayer).toEqualTypeOf<Layer.Layer<Fetch, never, never>>();
+  });
+
+  test('works with plain Response', async () => {
+    const mockFetch = makeMockLayer(() =>
+      Response.unsafeMake({ status: 200, ok: true, body: 'Hello' })
+    );
+
+    const result = await Effect.gen(function* () {
+      const fetch = yield* Fetch;
+      return yield* fetch(request);
+    }).pipe(Effect.provide(mockFetch), Effect.runPromiseExit);
+
+    expect(Exit.isSuccess(result)).toBe(true);
+  });
+
+  test('returns the mocked response body', async () => {
+    const mockFetch = makeMockLayer(() =>
+      Response.unsafeMake({ status: 200, ok: true, body: 'Hello' })
+    );
+
+    const result = await Effect.gen(function* () {
+      const fetch = yield* Fetch;
+      const response = yield* fetch(request);
+      return yield* Response.readText(response);
+    }).pipe(Effect.provide(mockFetch), Effect.runPromiseExit);
+
+    expect(Exit.isSuccess(result)).toBe(true);
+    if (Exit.isSuccess(result)) {
+      expect(result.value).toBe('Hello');
+    }
+  });
+
+  test('works with Effect returning Response', async () => {
+    const mockFetch = makeMockLayer(() =>
+      Effect.succeed(Response.unsafeMake({ status: 200, ok: true }))
+    );
+
+    const result = await Effect.gen(function* () {
+      const fetch = yield* Fetch;
+      return yield* fetch(request);
+    }).pipe(Effect.provide(mockFetch), Effect.runPromiseExit);
+
+    expect(Exit.isSuccess(result)).toBe(true);
+  });
+
+  test('receives request parameter', async () => {
+    const mockFetch = makeMockLayer((req) => {
+      if (Url.format(req.url).includes('/users')) {
+        return Response.unsafeMake({ status: 200, ok: true });
+      }
+
+      return Response.unsafeMake({ status: 404, ok: false });
+    });
+
+    const usersRequest = Request.unsafeMake({ url: 'https://example.com/users' });
+    const otherRequest = Request.unsafeMake({ url: 'https://example.com/other' });
+
+    const usersResult = await Effect.gen(function* () {
+      const fetch = yield* Fetch;
+      return yield* fetch(usersRequest);
+    }).pipe(Effect.provide(mockFetch), Effect.runPromiseExit);
+
+    const otherResult = await Effect.gen(function* () {
+      const fetch = yield* Fetch;
+      return yield* fetch(otherRequest);
+    }).pipe(Effect.provide(mockFetch), Effect.runPromiseExit);
+
+    expect(Exit.isSuccess(usersResult)).toBe(true);
+    expect(Exit.isFailure(otherResult)).toBe(true);
+  });
+
+  test('fails with NotOkError for non-ok response', async () => {
+    const mockFetch = makeMockLayer(() => Response.unsafeMake({ status: 500, ok: false }));
+
+    const result = await Effect.gen(function* () {
+      const fetch = yield* Fetch;
+      return yield* fetch(request);
+    }).pipe(Effect.provide(mockFetch), Effect.runPromiseExit);
+
+    expect(Exit.isFailure(result)).toBe(true);
+
+    if (Exit.isFailure(result)) {
+      const error = result.cause.pipe((cause) => (cause._tag === 'Fail' ? cause.error : undefined));
+      expect(error?._tag).toBe('NotOkError');
+    }
+  });
+
+  test('propagates errors from Effect', async () => {
+    const mockFetch = makeMockLayer(() =>
+      Effect.fail(new AbortError({ message: 'Request aborted', cause: undefined }))
+    );
+
+    const result = await Effect.gen(function* () {
+      const fetch = yield* Fetch;
+      return yield* fetch(request);
+    }).pipe(Effect.provide(mockFetch), Effect.runPromiseExit);
+
+    expect(Exit.isFailure(result)).toBe(true);
+
+    if (Exit.isFailure(result)) {
+      const error = result.cause.pipe((cause) => (cause._tag === 'Fail' ? cause.error : undefined));
+      expect(error?._tag).toBe('AbortError');
+    }
+  });
+});

--- a/packages/fx-fetch/src/Fetch/makeMockLayer.ts
+++ b/packages/fx-fetch/src/Fetch/makeMockLayer.ts
@@ -1,0 +1,63 @@
+import { type Effect, flatMap, isEffect, succeed } from 'effect/Effect';
+import { type Layer, succeed as layerSucceed } from 'effect/Layer';
+import type { Request } from '../Request';
+import { ensureOk } from '../Response';
+import { Fetch } from './Fetch';
+import type { Type } from './Type';
+
+type MockFn = (
+  request: Request
+) => Fetch.SuccessType | Effect<Fetch.SuccessType, Fetch.ErrorType, never>;
+
+/**
+ * Creates a mock Fetch layer for testing purposes.
+ *
+ * The mock function can return either a plain `Response` or an `Effect<Response, E>`
+ * for simulating both successful responses and error scenarios.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from 'effect';
+ * import { Fetch, Request, Response } from 'fx-fetch';
+ *
+ * // Mock returning a simple Response
+ * const mockLayer = Fetch.makeMockLayer(() =>
+ *   Response.unsafeMake({ status: 200, ok: true, body: 'Hello' })
+ * );
+ *
+ * Effect.gen(function* () {
+ *   const request = Request.unsafeMake({ url: 'https://example.com' });
+ *   const response = yield* Fetch.fetch(request);
+ * }).pipe(
+ *   Effect.provide(mockLayer), // ◀︎── Provide mock layer
+ *   Effect.runPromise
+ * );
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { Effect } from 'effect';
+ * import { Fetch, Request, Response, Url } from 'fx-fetch';
+ *
+ * // Mock using the request to return different responses
+ * const mockLayer = Fetch.makeMockLayer((request) => {
+ *   if (Url.format(request.url).includes('/users')) {
+ *     return Response.unsafeMake({ status: 200, ok: true, body: JSON.stringify([{ id: 1 }]) });
+ *   }
+ *
+ *   return Response.unsafeMake({ status: 404, ok: false });
+ * });
+ * ```
+ *
+ * @category Layers
+ * @since 1.2.0
+ */
+export const makeMockLayer = (mockFn: MockFn): Layer<Fetch, never, never> => {
+  const service: Type = (request: Request) => {
+    const result = mockFn(request);
+    const effect = isEffect(result) ? result : succeed(result);
+    return effect.pipe(flatMap(ensureOk));
+  };
+
+  return layerSucceed(Fetch, service);
+};

--- a/packages/fx-fetch/src/Request/Request.ts
+++ b/packages/fx-fetch/src/Request/Request.ts
@@ -86,5 +86,5 @@ export namespace Request {
    * @category Models
    * @since 0.1.0
    */
-  export type Input = Request | Parts | Options | localThis.Request;
+  export type Input = Request | Parts | Options | localThis.Request | string;
 }

--- a/packages/fx-fetch/src/Request/classifyRequestInput.ts
+++ b/packages/fx-fetch/src/Request/classifyRequestInput.ts
@@ -36,6 +36,13 @@ export function classifyRequestInput(input: Request.Input):
       readonly type: 'parts';
       readonly input: Request.Parts;
     } {
+  if (typeof input === 'string') {
+    return {
+      type: 'parts',
+      input: { url: input },
+    };
+  }
+
   if (isRequest(input)) {
     return {
       type: 'request',

--- a/packages/fx-fetch/src/Request/make.ts
+++ b/packages/fx-fetch/src/Request/make.ts
@@ -16,6 +16,15 @@ import { unsafeMake } from './unsafeMake';
  * });
  * ```
  *
+ * @example
+ * ```ts
+ * import { Request } from 'fx-fetch';
+ *
+ * //       ┌─── Option.Option<Request.Request>
+ * //       ▼
+ * const request = Request.make('https://example.com');
+ * ```
+ *
  * @category Constructors
  * @since 0.1.0
  */

--- a/packages/fx-fetch/src/Request/unsafeMake.ts
+++ b/packages/fx-fetch/src/Request/unsafeMake.ts
@@ -3,8 +3,6 @@ import { inputToRequestIntermediate } from './inputToRequestIntermediate';
 import { makeFromRequestIntermediate } from './makeFromRequestIntermediate';
 import type { Request } from './Request';
 
-// TODO: Add tests for dual APIs
-
 /**
  * Creates a immutable Request object. Throws an error if the input is invalid.
  *
@@ -18,6 +16,15 @@ import type { Request } from './Request';
  *   url: 'https://example.com',
  *   method: 'POST'
  * });
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { Request } from 'fx-fetch';
+ *
+ * //       ┌─── Request.Request
+ * //       ▼
+ * const request = Request.unsafeMake('https://example.com');
  * ```
  *
  * @category Constructors

--- a/packages/website/src/content/docs/fetch/index.mdx
+++ b/packages/website/src/content/docs/fetch/index.mdx
@@ -57,6 +57,31 @@ program.pipe(
 
 Having fetch as a service allows you to easily swap implementations for testing, mocking, or other purposes.
 
+### layer
+
+The `layer` export provides a convenient way to use the live Fetch implementation with Effect's layer composition.
+This is the recommended approach when building applications with multiple layers.
+
+```ts twoslash showLineNumbers=false
+import { Effect } from 'effect';
+import { Fetch, Request } from 'fx-fetch';
+
+const program = Effect.gen(function* () {
+  const request = Request.unsafeMake({ url: 'https://example.com' });
+  const response = yield* Fetch.fetch(request);
+});
+
+program.pipe(
+  Effect.provide(Fetch.layer), // ◀︎── Provide Fetch layer
+  Effect.runPromise
+);
+```
+
+:::tip
+Use `Fetch.layer` when composing with other layers using `Layer.merge` or `Layer.provide`.
+Use `Effect.provideService(Fetch.Fetch, Fetch.FetchLive)` for simple, one-off usage.
+:::
+
 ### fetchJson
 
 The `fetchJson` function is a helper that combines `fetch` with [`Response.readJson`](../response/#readjson). It is syntactic sugar for better ergonomics.
@@ -273,6 +298,160 @@ const program = Fetch.paginatedFetchStream(
       nextRequest, // ◀︎── Option.Option<Request.Request>
     };
   })
+);
+```
+
+## Middleware
+
+The `makeMiddlewareLayer` function creates a middleware Layer that allows customizing request and response handling.
+This is useful for adding cross-cutting concerns like authentication, logging, or request transformation.
+
+### makeMiddlewareLayer
+
+The middleware can transform requests before they are sent and responses after they are received.
+Both `mapRequest` and `mapResponse` are optional - if not provided, they pass through unchanged.
+
+**Execution order:** `mapRequest → fetch → mapResponse → ensureOk`
+
+```ts twoslash showLineNumbers=false
+import { Effect } from 'effect';
+import { Fetch, Request, Response } from 'fx-fetch';
+
+//       ┌─── Layer<Fetch, never, never>
+//       ▼
+const authMiddlewareLayer = Fetch.makeMiddlewareLayer({
+  mapRequest: (request) =>
+    Effect.succeed(
+      Request.appendHeaders(request, { Authorization: 'Bearer token' })
+    ),
+});
+
+const program = Effect.gen(function* () {
+  const request = Request.unsafeMake({ url: 'https://api.example.com/data' });
+  const response = yield* Fetch.fetch(request);
+});
+
+program.pipe(
+  Effect.provide(authMiddlewareLayer), // ◀︎── Middleware adds Authorization header
+  Effect.runPromise
+);
+```
+
+#### Middleware with Dependencies
+
+The middleware layer properly tracks Effect requirements, allowing you to inject dependencies like configuration services.
+
+```ts twoslash showLineNumbers=false
+import { Context, Effect, Layer } from 'effect';
+import { Fetch, Request } from 'fx-fetch';
+
+// Service for configuration
+class Config extends Context.Tag('Config')<Config, { apiKey: string }>() {}
+
+//       ┌─── Layer<Fetch, never, Config>
+//       ▼
+const authMiddlewareLayer = Fetch.makeMiddlewareLayer({
+  mapRequest: (request) =>
+    Effect.gen(function* () {
+      const config = yield* Config;
+      return Request.appendHeaders(request, { 'X-API-Key': config.apiKey });
+    }),
+});
+
+const program = Effect.gen(function* () {
+  const request = Request.unsafeMake({ url: 'https://api.example.com/data' });
+  const response = yield* Fetch.fetch(request);
+});
+
+program.pipe(
+  Effect.provide(authMiddlewareLayer),
+  Effect.provide(Layer.succeed(Config, { apiKey: 'my-secret-key' })),
+  Effect.runPromise
+);
+```
+
+#### Response Transformation
+
+You can also transform or inspect responses using `mapResponse`.
+
+```ts twoslash showLineNumbers=false
+import { Effect } from 'effect';
+import { Fetch } from 'fx-fetch';
+
+const loggingMiddlewareLayer = Fetch.makeMiddlewareLayer({
+  mapResponse: (response) =>
+    Effect.gen(function* () {
+      yield* Effect.log(`Response status: ${response.status}`);
+      return response;
+    }),
+});
+```
+
+:::tip
+You can combine both `mapRequest` and `mapResponse` in the same middleware to handle complete request/response lifecycle.
+:::
+
+## Testing
+
+The `makeMockLayer` function creates a mock Fetch layer for testing purposes.
+This allows you to test your code without making actual HTTP requests.
+
+### makeMockLayer
+
+The mock function receives the [`Request`](../request/) and can return either:
+- A plain [`Response`](../response/) object
+- An `Effect<Response, Error>` for simulating async behavior or errors
+
+```ts twoslash showLineNumbers=false
+import { Effect } from 'effect';
+import { Fetch, Request, Response } from 'fx-fetch';
+
+// Mock returning a simple Response
+const mockLayer = Fetch.makeMockLayer(() =>
+  Response.unsafeMake({ status: 200, ok: true, body: 'Hello' })
+);
+
+const program = Effect.gen(function* () {
+  const request = Request.unsafeMake({ url: 'https://example.com' });
+  const response = yield* Fetch.fetch(request);
+});
+
+program.pipe(
+  Effect.provide(mockLayer), // ◀︎── Uses mock instead of real fetch
+  Effect.runPromise
+);
+```
+
+#### Request-Aware Mocking
+
+The mock function receives the request, allowing you to return different responses based on the URL, headers, or other request properties.
+
+```ts twoslash showLineNumbers=false
+import { Fetch, Response, Url } from 'fx-fetch';
+
+const mockLayer = Fetch.makeMockLayer((request) => {
+  if (Url.format(request.url).includes('/users')) {
+    return Response.unsafeMake({
+      status: 200,
+      ok: true,
+      body: JSON.stringify([{ id: 1, name: 'Alice' }]),
+    });
+  }
+
+  return Response.unsafeMake({ status: 404, ok: false });
+});
+```
+
+#### Error Simulation
+
+You can simulate errors by returning an `Effect.fail` from the mock function.
+
+```ts twoslash showLineNumbers=false
+import { Effect } from 'effect';
+import { Fetch } from 'fx-fetch';
+
+const mockLayer = Fetch.makeMockLayer(() =>
+  Effect.fail(new Fetch.AbortError({ message: 'Request was aborted', cause: new Error() }))
 );
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR implements fetch middleware by introducing a dependency injection layer and refactoring the fetch execution pipeline:

**Core Changes:**
- Added `Fetch.layer` for dependency injection, providing the Fetch service through `FetchLive`
- Created `executeFetch()` function that encapsulates fetch logic, error mapping (TypeError → FetchError, AbortError/NotAllowedError handling), and response conversion
- Refactored `FetchLive` to delegate to the new `executeFetch` pipeline with simplified error handling
- Added `makeMockLayer()` for testing, supporting both plain Response objects and Effect-based mock responses

**Request Module:**
- Extended `Request.Input` type to include `string` for direct URL input
- Updated `classifyRequestInput()` to handle string inputs
- Added documentation examples for string URL usage

**Configuration:**
- Added `.claude/settings.json` with permissions for Claude AI tool usage
- Updated `nx.json` to enable caching for `fmt`, `fmt:write`, `validate`, and `test` targets
- Made `test` target depend on `fmt` for consistent code formatting

**Testing:**
- Added `layer.test.ts` for Fetch layer integration tests
- Added `makeMockLayer.test.ts` with comprehensive mock functionality tests

**Exports:**
- Exposed `layer` and `makeMockLayer` from the public API

<!-- end of auto-generated comment: release notes by coderabbit.ai -->