### PR TITLE
chore: remove TODO comments for dual API tests and examples across multiple files

### DIFF
--- a/packages/fx-fetch/src/Fetch/paginatedFetch.ts
+++ b/packages/fx-fetch/src/Fetch/paginatedFetch.ts
@@ -12,8 +12,6 @@ function paginatedFetchFn<A, E, R>(request: Request, onResponse: OnResponse<A, E
   return paginatedFetchStream(request, onResponse).pipe(runCollect, map(toReadonlyArray));
 }
 
-// TODO: Add tests for dual APIs
-
 /**
  * @category Functions
  * @since 0.1.0

--- a/packages/fx-fetch/src/Fetch/paginatedFetchStream.ts
+++ b/packages/fx-fetch/src/Fetch/paginatedFetchStream.ts
@@ -31,8 +31,6 @@ function paginatedFetchStreamFn<A, E, R>(request: Request, onResponse: OnRespons
   );
 }
 
-// TODO: Add tests for dual APIs
-
 /**
  * @category Functions
  * @since 0.1.0

--- a/packages/fx-fetch/src/Request/readJsonWithSchema.ts
+++ b/packages/fx-fetch/src/Request/readJsonWithSchema.ts
@@ -9,9 +9,6 @@ import { readJson } from './readJson';
 const readJsonWithSchemaFn = <A, I, R>(self: Request, schema: Schema<A, I, R>) =>
   readJson(self).pipe(flatMap(decodeUnknown(schema)));
 
-// TODO: Add tests
-// TODO: Add tests for dual APIs
-
 /**
  * Reads a JSON request with the given schema.
  *

--- a/packages/fx-fetch/src/Request/readStream.ts
+++ b/packages/fx-fetch/src/Request/readStream.ts
@@ -21,9 +21,6 @@ const readStreamFn = <E>(self: Request, options: Options<E>) =>
     )
   );
 
-// TODO: Add tests for dual APIs
-// TODO: Add examples
-
 /**
  * Reads a ReadableStream request.
  *

--- a/packages/fx-fetch/src/Request/setUrlSearchParam.ts
+++ b/packages/fx-fetch/src/Request/setUrlSearchParam.ts
@@ -8,8 +8,6 @@ function setUrlSearchParamFn(self: Request, key: string, value: SearchParamValue
   return mapUrl(self, (url) => setSearchParam(url, key, value));
 }
 
-// TODO: Add tests for dual APIs
-
 /**
  * Sets a search parameter in the URL of a Request.
  *

--- a/packages/fx-fetch/src/Request/unsafeMake.ts
+++ b/packages/fx-fetch/src/Request/unsafeMake.ts
@@ -3,8 +3,6 @@ import { inputToRequestIntermediate } from './inputToRequestIntermediate';
 import { makeFromRequestIntermediate } from './makeFromRequestIntermediate';
 import type { Request } from './Request';
 
-// TODO: Add tests for dual APIs
-
 /**
  * Creates a immutable Request object. Throws an error if the input is invalid.
  *

--- a/packages/fx-fetch/src/Request/unsafeSetUrl.ts
+++ b/packages/fx-fetch/src/Request/unsafeSetUrl.ts
@@ -19,9 +19,6 @@ function unsafeSetUrlFn(self: Request, url: Url.Input): Request {
   return makeFromRequestIntermediate(intermediate);
 }
 
-// TODO: Add tests for dual APIs
-// TODO: Add examples
-
 /**
  * Unsafely sets the URL of a Request (throws on invalid).
  *

--- a/packages/fx-fetch/src/Response/readJsonWithSchema.ts
+++ b/packages/fx-fetch/src/Response/readJsonWithSchema.ts
@@ -9,9 +9,6 @@ import { readJson } from './readJson';
 const readJsonWithSchemaFn = <A, I, R>(response: Response, schema: Schema<A, I, R>) =>
   readJson(response).pipe(flatMap(decodeUnknown(schema)));
 
-// TODO: Add tests
-// TODO: Add tests for dual APIs
-
 /**
  * Reads a JSON response with the given schema.
  *

--- a/packages/fx-fetch/src/Response/readStream.ts
+++ b/packages/fx-fetch/src/Response/readStream.ts
@@ -21,9 +21,6 @@ const readStreamFn = <E>(response: Response, options: Options<E>) =>
     )
   );
 
-// TODO: Add tests for dual APIs
-// TODO: Add examples
-
 /**
  * Reads a ReadableStream response.
  *

--- a/packages/fx-fetch/src/Response/unsafeMake.ts
+++ b/packages/fx-fetch/src/Response/unsafeMake.ts
@@ -3,10 +3,6 @@ import { inputToResponseIntermediate } from './inputToResponseIntermediate';
 import { makeFromResponseIntermediate } from './makeFromResponseIntermediate';
 import type { Response } from './Response';
 
-// TODO: Add tests for dual APIs
-// TODO: Add examples
-// TODO: Add annotations
-
 /**
  * Creates a immutable Response object.
  *


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request removes TODO comments related to dual API tests and examples across 10 files in the `packages/fx-fetch/src/` directory:

- `Fetch/paginatedFetch.ts` (-2 lines)
- `Fetch/paginatedFetchStream.ts` (-2 lines)
- `Request/readJsonWithSchema.ts` (-3 lines)
- `Request/readStream.ts` (-3 lines)
- `Request/setUrlSearchParam.ts` (-2 lines)
- `Request/unsafeMake.ts` (-2 lines)
- `Request/unsafeSetUrl.ts` (-3 lines)
- `Response/readJsonWithSchema.ts` (-3 lines)
- `Response/readStream.ts` (-3 lines)
- `Response/unsafeMake.ts` (-4 lines)

A total of 27 lines of TODO comments are removed with no changes to logic, exports, or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->